### PR TITLE
Add active application set volume action

### DIFF
--- a/VolumeControl.HotkeyActions/ActiveApplicationActions.cs
+++ b/VolumeControl.HotkeyActions/ActiveApplicationActions.cs
@@ -21,6 +21,9 @@ namespace VolumeControl.HotkeyActions
         // Volume Step
         private const string Setting_VolumeStep_Name = "Volume Step Override";
         private const string Setting_VolumeStep_Description = "Overrides the default volume step for this action.";
+        // Volume Level
+        private const string Setting_VolumeLevel_Name = "Volume Level";
+        private const string Setting_VolumeLevel_Description = "The volume level to set the current foreground application to.";
         #endregion Fields
 
         #region Properties
@@ -128,6 +131,32 @@ namespace VolumeControl.HotkeyActions
             {
                 session.Mute = true;
             }
+            if (sessions.Count > 0)
+            {
+                if (e.GetValue<bool>(Setting_SelectTarget_Name))
+                {
+                    VCAPI.AudioSessionMultiSelector.SetSelectedSessionsOrCurrentSession(sessions);
+                }
+                VCAPI.ShowSessionListNotification(sessions);
+            }
+        }
+        [HotkeyAction(Description = "Sets the volume of the current foreground application.")]
+        [HotkeyActionSetting(Setting_SelectTarget_Name, typeof(bool), Description = Setting_SelectTarget_Description)]
+        [HotkeyActionSetting(Setting_VolumeLevel_Name, typeof(int), "VolumeLevelDataTemplate", DefaultValue = 50, Description = Setting_VolumeLevel_Description, IsToggleable = true, StartsEnabled = true)]
+        public void SetVolume(object? sender, HotkeyPressedEventArgs e)
+        {
+            var (setVolumeLevel, volumeLevel) = e.GetSetting<int>(Setting_VolumeLevel_Name);
+
+            if (!setVolumeLevel)
+                return;
+
+            var sessions = GetActiveSessions();
+
+            foreach (var session in sessions)
+            {
+                session.Volume = volumeLevel;
+            }
+
             if (sessions.Count > 0)
             {
                 if (e.GetValue<bool>(Setting_SelectTarget_Name))

--- a/VolumeControl.HotkeyActions/Localization/en-HotkeyActions.loc.json
+++ b/VolumeControl.HotkeyActions/Localization/en-HotkeyActions.loc.json
@@ -323,6 +323,14 @@
           "Description": {
             "English (US/CA)": "Overrides the global volume step for this action."
           }
+        },
+        "Volume Level": {
+          "Name": {
+            "English (US/CA)": "Volume Level"
+          },
+          "Description": {
+            "English (US/CA)": "The volume level to set the current foreground application to."
+          }
         }
       },
 
@@ -340,6 +348,14 @@
         },
         "Description": {
           "English (US/CA)": "Decreases the volume of the current foreground application."
+        }
+      },
+      "SetVolume": {
+        "Name": {
+          "English (US/CA)": "Set Volume"
+        },
+        "Description": {
+          "English (US/CA)": "Sets the volume of the current foreground application."
         }
       },
       "Mute": {

--- a/VolumeControl.HotkeyActions/Localization/it-HotkeyActions.loc.json
+++ b/VolumeControl.HotkeyActions/Localization/it-HotkeyActions.loc.json
@@ -296,6 +296,14 @@
           "Description": {
             "Italiano (Italian)": "Sovrascrivi step globali volume per questa azione."
           }
+        },
+        "Volume Level": {
+          "Name": {
+            "Italiano (Italian)": "Livello volume"
+          },
+          "Description": {
+            "Italiano (Italian)": "Il livello del volume a cui impostare l'applicazione attuale in primo piano."
+          }
         }
       },
 
@@ -313,6 +321,14 @@
         },
         "Description": {
           "Italiano (Italian)": "Diminuisci il volume dell'applicazione attuale in primo piano."
+        }
+      },
+      "SetVolume": {
+        "Name": {
+          "Italiano (Italian)": "Imposta volume"
+        },
+        "Description": {
+          "Italiano (Italian)": "Imposta il volume dell'applicazione attuale in primo piano."
         }
       },
       "Mute": {

--- a/VolumeControl.HotkeyActions/Localization/zz-HotkeyActions.loc.json
+++ b/VolumeControl.HotkeyActions/Localization/zz-HotkeyActions.loc.json
@@ -293,6 +293,14 @@
           "Description": {
             "Debug (/)": "TEST Overrides the global volume step for this action."
           }
+        },
+        "Volume Level": {
+          "Name": {
+            "Debug (/)": "TEST Volume Level"
+          },
+          "Description": {
+            "Debug (/)": "TEST The volume level to set the current foreground application to."
+          }
         }
       },
 
@@ -310,6 +318,14 @@
         },
         "Description": {
           "Debug (/)": "TEST Decreases the volume of the current foreground application."
+        }
+      },
+      "SetVolume": {
+        "Name": {
+          "Debug (/)": "TEST Set Volume"
+        },
+        "Description": {
+          "Debug (/)": "TEST Sets the volume of the current foreground application."
         }
       },
       "Mute": {


### PR DESCRIPTION
## Summary
- add a Set Volume hotkey action for the active application group
- expose a configurable target volume level for the active application action settings
- translate the new action and setting in the localization resources

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e55a33f604832cb7eba5f94f253f0f